### PR TITLE
Update deprecated 'include' module to 'import_tasks'

### DIFF
--- a/roles/apps/tasks/main.yml
+++ b/roles/apps/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 # tasks file for apps
 - name: Install my commonly used apps
-  include: tasks.yaml
+  import_tasks: tasks.yaml
   become: yes
   tags: apps

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -2,11 +2,11 @@
 # tasks file for roles/base
 
 - name: Upgrade and install all the things
-  include: update.yaml
+  import_tasks: update.yaml
   become: yes
   tags: update,upgrade
 
 - name: Install common packages
-  include: install.yaml
+  import_tasks: install.yaml
   become: yes
   tags: install_common

--- a/roles/environment/tasks/main.yml
+++ b/roles/environment/tasks/main.yml
@@ -2,7 +2,7 @@
 # tasks file for environment
 
 - name: Install relevent environment packages
-  include: tasks.yaml
+  import_tasks: tasks.yaml
   become: yes
   tags: environment
 


### PR DESCRIPTION
The error I received was: "include" is deprecated, use include_tasks/import_tasks instead.

I think this should fix is, `import_tasks` is for static tasks, while `include_tasks` is for more dynamic tasks.

Source: [whats-the-difference-between-include-tasks-and-import-tasks](https://serverfault.com/questions/875247/whats-the-difference-between-include-tasks-and-import-tasks)